### PR TITLE
Export 'saveAs' global function for Meteor package

### DIFF
--- a/lib/FileSaver.js
+++ b/lib/FileSaver.js
@@ -12,7 +12,7 @@
 
 /*! @source http://purl.eligrey.com/github/FileSaver.js/blob/master/FileSaver.js */
 
-var saveAs = saveAs || (function(view) {
+saveAs = saveAs || (function(view) {
 	"use strict";
 	// IE <10 is explicitly unsupported
 	if (typeof navigator !== "undefined" && /MSIE [1-9]\./.test(navigator.userAgent)) {

--- a/package.js
+++ b/package.js
@@ -6,6 +6,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
+  api.export(['saveAs'])
   api.versionsFrom("METEOR@1.0");
 	api.add_files('lib/FileSaver.js', 'client');
 });


### PR DESCRIPTION
I found the package unusable (Meteor 1.2) from another package until making this change, because the saveAs function was not exported as a global to the client.
